### PR TITLE
Fixes send on closed channel bug

### DIFF
--- a/irc/client.go
+++ b/irc/client.go
@@ -235,6 +235,7 @@ func (client *Client) destroy() {
 	}
 
 	close(client.replies)
+	client.replies = nil
 
 	client.socket.Close()
 
@@ -351,7 +352,9 @@ func (client *Client) ChangeNickname(nickname Name) {
 }
 
 func (client *Client) Reply(reply string) {
-	client.replies <- reply
+	if client.replies != nil {
+		client.replies <- reply
+	}
 }
 
 func (client *Client) Quit(message Text) {


### PR DESCRIPTION
Fixes #28

Haven't been able to locally reproduce; but this should guard against
sending on a closed channel if we set `client.replies` to `nil` and
use that as a condition before attempting writes.