### PR TITLE
Adds support for measuring secure vs. non-secure registerd clients

### DIFF
--- a/irc/client.go
+++ b/irc/client.go
@@ -222,6 +222,12 @@ func (client *Client) destroy() {
 
 	// clean up server
 
+	if _, ok := client.socket.conn.(*tls.Conn); ok {
+		client.server.metrics.GaugeVec("server", "clients").WithLabelValues("secure").Dec()
+	} else {
+		client.server.metrics.GaugeVec("server", "clients").WithLabelValues("insecure").Dec()
+	}
+
 	client.server.connections.Dec()
 	client.server.clients.Remove(client)
 

--- a/irc/server.go
+++ b/irc/server.go
@@ -123,13 +123,20 @@ func NewServer(config *Config) *Server {
 		},
 	)
 
-	// server clients gauge
+	// server registered (clients) gauge
 	server.metrics.NewGaugeFunc(
-		"server", "clients",
+		"server", "registered",
 		"Number of registered clients connected",
 		func() float64 {
 			return float64(server.clients.Count())
 		},
+	)
+
+	// server clients gauge (by secure/insecire)
+	server.metrics.NewGaugeVec(
+		"server", "clients",
+		"Number of registered clients connected (by secure/insecure)",
+		[]string{"secure"},
 	)
 
 	// server channels gauge
@@ -216,6 +223,12 @@ func (s *Server) acceptor(listener net.Listener) {
 			continue
 		}
 		log.Debugf("%s accept: %s", s, conn.RemoteAddr())
+
+		if _, ok := conn.(*tls.Conn); ok {
+			s.metrics.GaugeVec("server", "clients").WithLabelValues("secure").Inc()
+		} else {
+			s.metrics.GaugeVec("server", "clients").WithLabelValues("insecure").Inc()
+		}
 
 		s.connections.Inc()
 		s.newConns <- conn


### PR DESCRIPTION
Closes #33

Tested locally:

```#!bash
$ curl -s -q -o - http://localhost:9314/ | grep eris_server_clients
eris_server_clients{secure="insecure"} 1
eris_server_clients{secure="secure"} 1
```