### PR TITLE
Adds support for multi-layer channel privacy (Public, Private and Secret)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ Discussion at:
 * /server irc.mills.io +6697 (*use TLS/SSL*)
 * /join #lobby
 
-Or (*not recommended*)P
+Or (**not recommended**):
 
-* /server irc.mills.io (*default port 6667, non-TLS)
+* /server irc.mills.io (*default port 6667, non-TLS*)
 * /join #lobby
 
 ## Features
@@ -54,6 +54,7 @@ Or (*not recommended*)P
 * Simple IRC operator privileges (*overrides most things*)
 * Secure connection tracking (+z) and SecureOnly user mode (+Z)
 * Secure channels (+Z)
+* Three layers of channel privacy, Public, Private (+p) and Secret (s)
 
 ## Quick Start
 

--- a/irc/channel.go
+++ b/irc/channel.go
@@ -374,7 +374,7 @@ func (channel *Channel) applyMode(client *Client, change *ChannelModeChange) boo
 		return channel.applyModeMask(client, change.mode, change.op,
 			NewName(change.arg))
 
-	case InviteOnly, Moderated, NoOutside, OpOnlyTopic, Private, SecureChan:
+	case InviteOnly, Moderated, NoOutside, OpOnlyTopic, Private, Secret, SecureChan:
 		return channel.applyModeFlag(client, change.mode, change.op)
 
 	case Key:

--- a/irc/modes.go
+++ b/irc/modes.go
@@ -70,7 +70,6 @@ var (
 )
 
 const (
-	Anonymous       ChannelMode = 'a' // flag
 	BanMask         ChannelMode = 'b' // arg
 	ChannelCreator  ChannelMode = 'O' // flag
 	ChannelOperator ChannelMode = 'o' // arg
@@ -82,8 +81,6 @@ const (
 	NoOutside       ChannelMode = 'n' // flag
 	OpOnlyTopic     ChannelMode = 't' // flag
 	Private         ChannelMode = 'p' // flag
-	Quiet           ChannelMode = 'q' // flag
-	ReOp            ChannelMode = 'r' // flag
 	Secret          ChannelMode = 's' // flag, deprecated
 	UserLimit       ChannelMode = 'l' // flag arg
 	Voice           ChannelMode = 'v' // arg
@@ -93,7 +90,7 @@ const (
 var (
 	SupportedChannelModes = ChannelModes{
 		BanMask, ExceptMask, InviteMask, InviteOnly, Key, NoOutside,
-		OpOnlyTopic, Private, UserLimit, SecureChan,
+		OpOnlyTopic, Private, UserLimit, Secret, SecureChan,
 	}
 )
 

--- a/irc/privacy.go
+++ b/irc/privacy.go
@@ -1,0 +1,22 @@
+package irc
+
+func CanSeeChannel(client *Client, channel *Channel) bool {
+	isPrivate := channel.flags.Has(Private)
+	isSecret := channel.flags.Has(Secret)
+
+	isMember := channel.members.Has(client)
+	isOperator := client.flags[Operator]
+	isRegistered := client.flags[Registered]
+	isSecure := client.flags[SecureConn]
+
+	if !(isSecret || isPrivate) {
+		return true
+	}
+	if isSecret && (isMember || isOperator) {
+		return true
+	}
+	if isPrivate && (isMember || isOperator || (isRegistered && isSecure)) {
+		return true
+	}
+	return false
+}

--- a/irc/reply.go
+++ b/irc/reply.go
@@ -489,8 +489,13 @@ func (target *Client) RplMOTDEnd() {
 }
 
 func (target *Client) RplList(channel *Channel) {
-	target.NumericReply(RPL_LIST,
-		"%s %d :%s", channel, channel.members.Count(), channel.topic)
+	target.NumericReply(
+		RPL_LIST,
+		"%s %d :%s",
+		channel,
+		channel.members.Count(),
+		channel.topic,
+	)
 }
 
 func (target *Client) RplListEnd(server *Server) {
@@ -504,8 +509,12 @@ func (target *Client) RplNamReply(channel *Channel) {
 }
 
 func (target *Client) RplWhoisChannels(client *Client) {
-	target.MultilineReply(client.WhoisChannelsNames(), RPL_WHOISCHANNELS,
-		"%s :%s", client.Nick())
+	target.MultilineReply(
+		client.WhoisChannelsNames(target),
+		RPL_WHOISCHANNELS,
+		"%s :%s",
+		client.Nick(),
+	)
 }
 
 func (target *Client) RplVersion() {


### PR DESCRIPTION
Closes #35

This implements three layers of channel privacy:

* Public -- no special meaning; anyone can see the channel
* Private (+p) -- Only members, IRC Operators or Users that are both
  connected securely and registered can see the channel
* Secret (+s) -- Only members or IRC Operators can see the channel

In all cases the "privacy" restrictions are respected for `/LIST` and `/WHOIS`
queries.

/cc @bear