### PR TITLE
I added I2P and Tor support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/DanielOaks/girc-go v0.0.0-20180430075055-8d136c4f9287
+	github.com/cretz/bine v0.1.0
 	github.com/eyedeekay/sam3 v0.32.31
 	github.com/google/uuid v1.1.0 // indirect
 	github.com/goshuirc/e-nfa v0.0.0-20160917075329-7071788e3940 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/DanielOaks/girc-go v0.0.0-20180430075055-8d136c4f9287
+	github.com/eyedeekay/sam3 v0.32.31
 	github.com/google/uuid v1.1.0 // indirect
 	github.com/goshuirc/e-nfa v0.0.0-20160917075329-7071788e3940 // indirect
 	github.com/imdario/mergo v0.3.11

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/eyedeekay/sam3 v0.32.31 h1:0fdDAupEQZSETHcyVQAsnFgpYArGJzU+lC2qN6f0GDk=
+github.com/eyedeekay/sam3 v0.32.31/go.mod h1:qRA9KIIVxbrHlkj+ZB+OoxFGFgdKeGp1vSgPw26eOVU=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
@@ -88,6 +90,7 @@ golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.4 h1:0YWbFKbhXG/wIiuHDSKpS0Iy7FSA+u45VtBMfQcFTTc=
 golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLM
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
+github.com/cretz/bine v0.1.0 h1:1/fvhLE+fk0bPzjdO5Ci+0ComYxEMuB1JhM4X5skT3g=
+github.com/cretz/bine v0.1.0/go.mod h1:6PF6fWAvYtwjRGkAuDEJeWNOv3a2hUouSP/yRYXmvHw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -76,6 +78,7 @@ github.com/thoj/go-ircevent v0.0.0-20180816043103-14f3614f28c3/go.mod h1:QYOctLs
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9 h1:mKdxBk7AujPs8kU4m80U72y/zjbZ3UcXC7dClwKbUI0=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/net v0.0.0-20181114220301-adae6a3d119a h1:gOpx8G595UYyvj8UK4+OFyY4rx037g3fmfhe5SasG3U=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/irc/config.go
+++ b/irc/config.go
@@ -26,6 +26,12 @@ type I2PConfig struct {
 	Base32  string
 }
 
+type TorConfig struct {
+	Torkeys     string
+	ControlPort int
+	Onion       string
+}
+
 func (conf *PassConfig) PasswordBytes() []byte {
 	bytes, err := DecodePassword(conf.Password)
 	if err != nil {
@@ -47,6 +53,7 @@ type Config struct {
 		Listen      []string
 		TLSListen   map[string]*TLSConfig
 		I2PListen   map[string]*I2PConfig
+		TorListen   map[string]*TorConfig
 		Log         string
 		MOTD        string
 		Name        string

--- a/irc/config.go
+++ b/irc/config.go
@@ -59,8 +59,15 @@ type Config struct {
 		Description string
 	}
 
-	Operator map[string]*PassConfig
-	Account  map[string]*PassConfig
+	WWW struct {
+		Listen    []string
+		TLSListen map[string]*TLSConfig
+		I2PListen map[string]*I2PConfig
+		TorListen map[string]*TorConfig
+	}
+	Operator    map[string]*PassConfig
+	Account     map[string]*PassConfig
+	TemplateDir string
 }
 
 func (conf *Config) Operators() map[Name][]byte {
@@ -125,9 +132,67 @@ func LoadConfig(filename string) (config *Config, err error) {
 		return nil, errors.New("Server name must match the format of a hostname")
 	}
 
-	if len(config.Server.Listen)+len(config.Server.TLSListen)+len(config.Server.I2PListen) == 0 {
+	if len(config.Server.Listen)+len(config.Server.TLSListen)+len(config.Server.I2PListen)+len(config.Server.TorListen) == 0 {
 		return nil, errors.New("Server listening addresses missing")
 	}
 
 	return config, nil
+}
+
+func (config *Config) WWWAddrs() string {
+	s := ""
+	for _, addr := range config.WWW.Listen {
+		s += addr + "\n"
+	}
+	return s
+}
+func (config *Config) TLSWWWAddrs() string {
+	s := ""
+	for addr := range config.WWW.TLSListen {
+		s += addr + "\n"
+	}
+	return s
+}
+func (config *Config) I2PWWWAddrs() string {
+	s := ""
+	for addr, i2pconfig := range config.WWW.I2PListen {
+		s += addr + ": " + i2pconfig.Base32 + "\n"
+	}
+	return s
+}
+func (config *Config) TorWWWAddrs() string {
+	s := ""
+	for addr, torconfig := range config.WWW.TorListen {
+		s += addr + ": " + torconfig.Onion + "\n"
+	}
+	return s
+}
+
+func (config *Config) IRCAddrs() string {
+	s := ""
+	for _, addr := range config.Server.Listen {
+		s += addr + "\n"
+	}
+	return s
+}
+func (config *Config) TLSIRCAddrs() string {
+	s := ""
+	for addr := range config.Server.TLSListen {
+		s += addr + "\n"
+	}
+	return s
+}
+func (config *Config) I2PIRCAddrs() string {
+	s := ""
+	for addr, i2pconfig := range config.Server.I2PListen {
+		s += addr + ": " + i2pconfig.Base32 + "\n"
+	}
+	return s
+}
+func (config *Config) TorIRCAddrs() string {
+	s := ""
+	for addr, torconfig := range config.Server.TorListen {
+		s += addr + ": " + torconfig.Onion + "\n"
+	}
+	return s
 }

--- a/irc/config.go
+++ b/irc/config.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"io/ioutil"
 	"log"
-	"os"
 	"sync"
 
 	"github.com/imdario/mergo"
@@ -131,20 +130,4 @@ func LoadConfig(filename string) (config *Config, err error) {
 	}
 
 	return config, nil
-}
-
-func (conf *Config) StoreConfig() error {
-	data, err := yaml.Marshal(conf)
-	if err != nil {
-		return err
-	}
-	info, err := os.Stat(conf.filename)
-	if err != nil {
-		return err
-	}
-	err = ioutil.WriteFile(conf.filename, data, info.Mode())
-	if err != nil {
-		return err
-	}
-	return nil
 }

--- a/irc/server.go
+++ b/irc/server.go
@@ -8,6 +8,7 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"os"
 	"os/signal"
@@ -379,13 +380,7 @@ func (s *Server) listentor(addr string, torconfig *TorConfig) {
 			log.Fatalf("Unable to write Tor keys to disk, %s", err)
 		}
 	} else if err == nil {
-		f, err := os.Open(torconfig.Torkeys)
-		if err != nil {
-			log.Fatalf("Unable to create Tor keys file for reading, %s", err)
-		}
-		defer f.Close()
-		tkeys := make([]byte, 64)
-		_, err = f.Read(tkeys)
+		tkeys, err := ioutil.ReadFile(torconfig.Torkeys)
 		if err != nil {
 			log.Fatalf("Unable to read Tor keys from disk")
 		}

--- a/irc/server.go
+++ b/irc/server.go
@@ -305,6 +305,11 @@ func (s *Server) listeni2p(addr string, i2pconfig *I2PConfig) {
 	}
 	var keys i2pkeys.I2PKeys
 	if _, err := os.Stat(i2pconfig.I2Pkeys); os.IsNotExist(err) {
+		f, err := os.Create(i2pconfig.I2Pkeys)
+		if err != nil {
+			log.Fatalf("Keyfile creation error: %s", err)
+		}
+		defer f.Close()
 		if err != nil {
 			log.Infof("Key loading error: %e", err)
 		}
@@ -312,7 +317,7 @@ func (s *Server) listeni2p(addr string, i2pconfig *I2PConfig) {
 		if err != nil {
 			log.Fatalf("Unable to load or generate I2P Keys, %s", err)
 		}
-		err = i2pkeys.StoreKeys(keys, i2pconfig.I2Pkeys)
+		err = i2pkeys.StoreKeysIncompat(keys, f)
 		if err != nil {
 			log.Fatalf("Unable to save newly generated I2P Keys, %s", err)
 		}

--- a/irc/server.go
+++ b/irc/server.go
@@ -484,7 +484,7 @@ func (s *Server) listentor(addr string, torconfig *TorConfig) {
 	if err != nil {
 		log.Fatalf("Unable to create onion service: %v", err)
 	}
-	log.Infof("Listening on Onion address, %s", listener.(*tor.OnionService).ID, torconfig.Onion, err)
+	log.Infof("Listening on Onion address, %s", torconfig.Onion)
 	go s.acceptor(listener)
 }
 

--- a/irc/server.go
+++ b/irc/server.go
@@ -352,8 +352,11 @@ func (s *Server) listeni2p(addr string, i2pconfig *I2PConfig) {
 	go s.acceptor(listener)
 }
 
+//
+// listen tor goroutine
+//
+
 func (s *Server) listentor(addr string, torconfig *TorConfig) {
-	// Start tor with default config (can set start conf's DebugWriter to os.Stdout for debug logs)
 	log.Infof("Starting and registering onion service, please wait a couple of minutes...")
 	t, err := tor.Start(nil, &tor.StartConf{ControlPort: torconfig.ControlPort})
 	if err != nil {
@@ -392,7 +395,7 @@ func (s *Server) listentor(addr string, torconfig *TorConfig) {
 		log.Fatalf("Unable to set up Tor keys, %s", err)
 	}
 	listenCtx := context.Background()
-	// Create a v3 onion service to listen on any port but show as 80
+	// Create a v3 onion service to listen on any port but show as 6667
 	listener, err := t.Listen(
 		listenCtx,
 		&tor.ListenConf{

--- a/irc/server.go
+++ b/irc/server.go
@@ -313,7 +313,10 @@ func (s *Server) listeni2p(addr string, i2pconfig *I2PConfig) {
 		if err != nil {
 			log.Fatalf("Unable to save newly generated I2P Keys, %s", err)
 		}
+		i2pconfig.Base32 = keys.Addr().Base32()
 	}
+	// If the keys and the base32 are different, keys win.
+	i2pconfig.Base32 = keys.Addr().Base32()
 
 	if err != nil {
 		log.Fatalf("error generating I2P keys %s: %s", addr, err)

--- a/irc/www.go
+++ b/irc/www.go
@@ -63,7 +63,6 @@ func (server *Server) ServeHTTP(rw http.ResponseWriter, rq *http.Request) {
 
 	rw.Header().Add("Content-Type", "text/html")
 	tmp := strings.Split(rq.URL.Path, "/")
-	log.Infof("URL Path%s", rq.URL.Path, tmp)
 	lang := "en"
 	if len(tmp) > 1 {
 		cleaned := strings.Replace(tmp[1], "/", "", -1)
@@ -76,10 +75,10 @@ func (server *Server) ServeHTTP(rw http.ResponseWriter, rq *http.Request) {
 	log.Infof("Rendering language: %d %s, %s", len(tmp), lang, server.templates[lang])
 	tmpl, err := template.New(server.config.Network.Name).Parse(server.templates[lang])
 	if err != nil {
-		log.Fatalf("Template generation error,", err)
+		log.Fatalf("Template generation error, %s", err)
 	}
 	err = tmpl.Execute(rw, server.config)
 	if err != nil {
-		log.Fatalf("Template execution error", err)
+		log.Fatalf("Template execution error, %s", err)
 	}
 }

--- a/irc/www.go
+++ b/irc/www.go
@@ -1,0 +1,85 @@
+package irc
+
+import (
+	//	"fmt"
+	log "github.com/sirupsen/logrus"
+	"html/template"
+	"net/http"
+	"strings"
+)
+
+var network_template string = `<html>
+<head>
+</head>
+<body>
+  <style>
+  body {
+    font-family: monospace;
+    font-size: large;
+  }
+  b   {
+    color: black;
+  }
+  p    {
+    color: darkgrey;
+  }
+  </style>
+  <h1>Network: {{ .Network.Name }}</h1>
+  <div>This is a web page intended to help your IRC users get the information
+they need to connect to your IRC network. It lists all your IRC server's addresses
+around the world.</div>
+`
+
+var server_template string = `
+  <div>
+    <h2>IRC Server Information</h2>
+    <ul>
+      <li><b>IRC Addresses: </b>{{ .IRCAddrs }}</li>
+      <li><b>TLS IRC Addresses: </b>{{ .TLSIRCAddrs }}</li>
+      <li><b>IRC I2P Addresses: </b>{{ .I2PIRCAddrs }}</li>
+      <li><b>IRC Tor Addresses: </b>{{ .TorIRCAddrs }}</li>
+      <li><b>Name: </b><span>{{ .Server.Name }}</span></li>
+      <li><b>Description: </b><span>{{ .Server.Description }}</span></li>
+    </ul>
+  </div>
+`
+
+var ops_template string = `
+  <div>
+    <h2>Web Server Information</h2>
+    <ul>
+      <li><b>Help Page Addresses on the Web: </b>{{ .WWWAddrs }}</li>
+      <li><b>TLS Addresses on the Web(HTTPS): </b>{{ .TLSWWWAddrs }}</li>
+      <li><b>Web Addresses on I2P: </b>{{ .I2PWWWAddrs }}</li>
+      <li><b>Web Addresses on Tor: </b>{{ .TorWWWAddrs }}</li>
+    </ul>
+  </div>
+</body>
+`
+
+var default_template string = network_template + server_template + ops_template
+
+func (server *Server) ServeHTTP(rw http.ResponseWriter, rq *http.Request) {
+
+	rw.Header().Add("Content-Type", "text/html")
+	tmp := strings.Split(rq.URL.Path, "/")
+	log.Infof("URL Path%s", rq.URL.Path, tmp)
+	lang := "en"
+	if len(tmp) > 1 {
+		cleaned := strings.Replace(tmp[1], "/", "", -1)
+		if cleaned == "" {
+			lang = "en"
+		} else {
+			lang = cleaned
+		}
+	}
+	log.Infof("Rendering language: %d %s, %s", len(tmp), lang, server.templates[lang])
+	tmpl, err := template.New(server.config.Network.Name).Parse(server.templates[lang])
+	if err != nil {
+		log.Fatalf("Template generation error,", err)
+	}
+	err = tmpl.Execute(rw, server.config)
+	if err != nil {
+		log.Fatalf("Template execution error", err)
+	}
+}

--- a/ircd.yml
+++ b/ircd.yml
@@ -19,19 +19,13 @@ server:
       key: key.pem
       cert: cert.pem
   
-  # Addresses to listen on for Invisible Internet
-  # note that if you choose this option, your ircd.yml will be
-  # rewritten to include the I2P address of your IRC server.
-  # You will lose any comments in your ircd.yml file
+  # Instruct the server to listen as an I2P service.
   # i2plisten:
     # "invisibleirc":
       # i2pkeys: iirc
       # samaddr: "127.0.0.1:7656"
 
-  # Addresses to listen on for Tor Onion Services.
-  # note that if you choose this option, your ircd.yml will be
-  # rewritten to include the Onion address of your IRC server.
-  # You will lose any comments in your ircd.yml
+  # Instruct the server to listen as a Tor .onion service.
   # torlisten:
     # hiddenirc:
       # torkeys: tirc
@@ -58,3 +52,28 @@ account:
   admin:
    # password 'admin'
    password: JDJhJDA0JGtUU1JVc1JOUy9DbEh1WEdvYVlMdGVnclp6YnA3NDBOZGY1WUZhdTZtRzVmb1VKdXQ5ckZD
+
+
+# Start a web server to help people get the information they need to connect
+# to the IRC server.
+# www: 
+#   listen:
+#     - ":8080"
+#   tlslisten:
+#     ":8443":
+#       key: key.pem
+#       cert: cert.pem
+#   i2plisten:
+#     "i2pinfoirc":
+#       i2pkeys: iirc
+#       samaddr: "127.0.0.1:7656"
+#   torlisten:
+#     torinfoirc:
+#       torkeys: tirc
+#       controlport: 0
+#
+# This directory can be used to load templates for the informational web page
+# which can be used for alternate language support or custom pages.
+# templatedir: "lang"
+
+

--- a/ircd.yml
+++ b/ircd.yml
@@ -18,6 +18,12 @@ server:
     ":6697":
       key: key.pem
       cert: cert.pem
+  
+  # Addresses to listen on for Invisible Internet
+  i2plisten:
+    "invisibleirc":
+      i2pkeys: iirc.i2pkeys
+      samaddr: "127.0.0.1:7656"
 
   # password to login to the server
    # generated using  "mkpasswd" (from https://github.com/prologic/mkpasswd)

--- a/ircd.yml
+++ b/ircd.yml
@@ -73,7 +73,10 @@ account:
 #       controlport: 0
 #
 # This directory can be used to load templates for the informational web page
-# which can be used for alternate language support or custom pages.
+# which can be used for alternate language support or custom pages. Each temlate
+# must end with the file extension .template, and must be located in the top level
+# of the template directory. If unset or left blank, a default template in English
+# will be used instead.
 # templatedir: "lang"
 
 

--- a/ircd.yml
+++ b/ircd.yml
@@ -20,10 +20,22 @@ server:
       cert: cert.pem
   
   # Addresses to listen on for Invisible Internet
-  i2plisten:
-    "invisibleirc":
-      i2pkeys: iirc.i2pkeys
-      samaddr: "127.0.0.1:7656"
+  # note that if you choose this option, your ircd.yml will be
+  # rewritten to include the I2P address of your IRC server.
+  # You will lose any comments in your ircd.yml file
+  # i2plisten:
+    # "invisibleirc":
+      # i2pkeys: iirc.i2pkeys
+      # samaddr: "127.0.0.1:7656"
+
+  # Addresses to listen on for Tor Onion Services.
+  # note that if you choose this option, your ircd.yml will be
+  # rewritten to include the Onion address of your IRC server.
+  # You will lose any comments in your ircd.yml
+  # torlisten:
+    # hiddenirc:
+      # torkeys: tirc.torkeys
+      # controlport: 0
 
   # password to login to the server
    # generated using  "mkpasswd" (from https://github.com/prologic/mkpasswd)

--- a/ircd.yml
+++ b/ircd.yml
@@ -25,7 +25,7 @@ server:
   # You will lose any comments in your ircd.yml file
   # i2plisten:
     # "invisibleirc":
-      # i2pkeys: iirc.i2pkeys
+      # i2pkeys: iirc
       # samaddr: "127.0.0.1:7656"
 
   # Addresses to listen on for Tor Onion Services.
@@ -34,7 +34,7 @@ server:
   # You will lose any comments in your ircd.yml
   # torlisten:
     # hiddenirc:
-      # torkeys: tirc.torkeys
+      # torkeys: tirc
       # controlport: 0
 
   # password to login to the server

--- a/main.go
+++ b/main.go
@@ -45,4 +45,3 @@ func main() {
 
 	irc.NewServer(config).Run()
 }
-

--- a/main.go
+++ b/main.go
@@ -45,3 +45,4 @@ func main() {
 
 	irc.NewServer(config).Run()
 }
+

--- a/main_test.go
+++ b/main_test.go
@@ -38,7 +38,7 @@ func setupServer() *eris.Server {
 
 	// SASL
 	config.Account = map[string]*eris.PassConfig{
-		"admin": &eris.PassConfig{"JDJhJDA0JGtUU1JVc1JOUy9DbEh1WEdvYVlMdGVnclp6YnA3NDBOZGY1WUZhdTZtRzVmb1VKdXQ5ckZD"},
+		"admin": {"JDJhJDA0JGtUU1JVc1JOUy9DbEh1WEdvYVlMdGVnclp6YnA3NDBOZGY1WUZhdTZtRzVmb1VKdXQ5ckZD"},
 	}
 
 	server := eris.NewServer(config)


### PR DESCRIPTION
This PR adds support for the anonymous Tor and I2P networks.

This support is largely automatic, the user adds the required configuration information to ircd.yml, keys are generated or loaded from disk as needed. The application connects to the anonymous network, then writes it's cryptographic address to the ircd.yml. This currently has the side-effect of erasing comments from the ircd.yml. Alternatively, I could write the cryptographic address to another file. This allows a user with I2P or Tor installed to use the cryptographic address in lieu of an IP address or domain name, and allow anonymous connections.